### PR TITLE
Reproduce schema in production db

### DIFF
--- a/db/migrations/000001_init.down.sql
+++ b/db/migrations/000001_init.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+
+COMMIT;

--- a/db/migrations/000001_init.up.sql
+++ b/db/migrations/000001_init.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+
+COMMIT;

--- a/db/migrations/000002_add_uuid_extension.down.sql
+++ b/db/migrations/000002_add_uuid_extension.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP EXTENSION IF EXISTS "uuid-ossp";
+
+COMMIT;

--- a/db/migrations/000002_add_uuid_extension.up.sql
+++ b/db/migrations/000002_add_uuid_extension.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+COMMIT;

--- a/db/migrations/000003_reproduce_user_tables.down.sql
+++ b/db/migrations/000003_reproduce_user_tables.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+DROP TABLE IF EXISTS user_authentications;
+
+DROP TABLE IF EXISTS users;
+
+DROP TYPE IF EXISTS user_authentications_provider_enum;
+
+COMMIT;

--- a/db/migrations/000003_reproduce_user_tables.up.sql
+++ b/db/migrations/000003_reproduce_user_tables.up.sql
@@ -1,0 +1,43 @@
+BEGIN;
+
+CREATE TYPE public.user_authentications_provider_enum AS ENUM (
+    'Google',
+    'Twitter',
+    'Apple'
+);
+
+CREATE TABLE public.user_authentications (
+    id integer NOT NULL,
+    provider public.user_authentications_provider_enum NOT NULL,
+    social_id character varying NOT NULL,
+    user_id uuid
+);
+
+CREATE SEQUENCE public.user_authentications_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.user_authentications_id_seq OWNED BY public.user_authentications.id;
+
+CREATE TABLE public.users (
+    id uuid NOT NULL,
+    "createdAt" timestamp without time zone DEFAULT now() NOT NULL,
+    "deletedAt" timestamp without time zone
+);
+
+ALTER TABLE ONLY public.user_authentications ALTER COLUMN id SET DEFAULT nextval('public.user_authentications_id_seq'::regclass);
+
+ALTER TABLE ONLY public.user_authentications
+    ADD CONSTRAINT "PK_5357fb1162b50b926c77290c8bc" PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT "PK_a3ffb1c0c8416b9fc6f907b7433" PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.user_authentications
+    ADD CONSTRAINT "FK_163ff5c9a502621798f57606e80" FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+COMMIT;

--- a/db/migrations/000004_reproduce_course_tables.down.sql
+++ b/db/migrations/000004_reproduce_course_tables.down.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+DROP TABLE IF EXISTS public.course_schedules;
+
+DROP TABLE IF EXISTS public.course_recommended_grades;
+
+DROP TABLE IF EXISTS public.course_methods;
+
+DROP INDEX IF EXISTS public."IDX_68ca51dc447bc2c03d5f1c44b8";
+
+DROP TABLE IF EXISTS public.courses;
+
+DROP SEQUENCE IF EXISTS public.course_schedules_id_seq;
+
+DROP SEQUENCE IF EXISTS public.course_recommended_grades_id_seq;
+
+DROP SEQUENCE IF EXISTS public.course_methods_id_seq;
+
+DROP TYPE IF EXISTS public.course_schedules_module_enum;
+
+DROP TYPE IF EXISTS public.course_schedules_day_enum;
+
+DROP TYPE IF EXISTS public.course_methods_method_enum;
+
+COMMIT;

--- a/db/migrations/000004_reproduce_course_tables.up.sql
+++ b/db/migrations/000004_reproduce_course_tables.up.sql
@@ -1,0 +1,131 @@
+BEGIN;
+
+CREATE TYPE public.course_methods_method_enum AS ENUM (
+    'OnlineAsynchronous',
+    'OnlineSynchronous',
+    'FaceToFace',
+    'Others'
+);
+
+CREATE TYPE public.course_schedules_day_enum AS ENUM (
+    'Sun',
+    'Mon',
+    'Tue',
+    'Wed',
+    'Thu',
+    'Fri',
+    'Sat',
+    'Intensive',
+    'Appointment',
+    'AnyTime',
+    'Unknown'
+);
+
+CREATE TYPE public.course_schedules_module_enum AS ENUM (
+    'SpringA',
+    'SpringB',
+    'SpringC',
+    'FallA',
+    'FallB',
+    'FallC',
+    'SummerVacation',
+    'SpringVacation',
+    'Annual',
+    'Unknown'
+);
+
+CREATE TABLE public.course_methods (
+    id integer NOT NULL,
+    method public.course_methods_method_enum NOT NULL,
+    course_id uuid
+);
+
+CREATE SEQUENCE public.course_methods_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.course_methods_id_seq OWNED BY public.course_methods.id;
+
+CREATE TABLE public.course_recommended_grades (
+    id integer NOT NULL,
+    grade smallint NOT NULL,
+    course_id uuid
+);
+
+CREATE SEQUENCE public.course_recommended_grades_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.course_recommended_grades_id_seq OWNED BY public.course_recommended_grades.id;
+
+CREATE TABLE public.course_schedules (
+    id integer NOT NULL,
+    module public.course_schedules_module_enum NOT NULL,
+    day public.course_schedules_day_enum NOT NULL,
+    period smallint NOT NULL,
+    room text NOT NULL,
+    course_id uuid
+);
+
+CREATE SEQUENCE public.course_schedules_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.course_schedules_id_seq OWNED BY public.course_schedules.id;
+
+CREATE TABLE public.courses (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    year smallint NOT NULL,
+    code text NOT NULL,
+    name text NOT NULL,
+    instructor text NOT NULL,
+    credit numeric NOT NULL,
+    overview text NOT NULL,
+    remarks text NOT NULL,
+    last_update timestamp with time zone NOT NULL,
+    has_parse_error boolean NOT NULL,
+    is_annual boolean DEFAULT false NOT NULL
+);
+
+ALTER TABLE ONLY public.course_methods ALTER COLUMN id SET DEFAULT nextval('public.course_methods_id_seq'::regclass);
+
+ALTER TABLE ONLY public.course_recommended_grades ALTER COLUMN id SET DEFAULT nextval('public.course_recommended_grades_id_seq'::regclass);
+
+ALTER TABLE ONLY public.course_schedules ALTER COLUMN id SET DEFAULT nextval('public.course_schedules_id_seq'::regclass);
+
+ALTER TABLE ONLY public.courses
+    ADD CONSTRAINT "PK_3f70a487cc718ad8eda4e6d58c9" PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.course_methods
+    ADD CONSTRAINT "PK_412b40a7891d105d69847f77f72" PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.course_schedules
+    ADD CONSTRAINT "PK_68118fc569f0c9ebb03fb79f80e" PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.course_recommended_grades
+    ADD CONSTRAINT "PK_832c34a40a52a56375e2796b3c6" PRIMARY KEY (id);
+
+CREATE UNIQUE INDEX "IDX_68ca51dc447bc2c03d5f1c44b8" ON public.courses USING btree (year, code);
+
+ALTER TABLE ONLY public.course_recommended_grades
+    ADD CONSTRAINT "FK_54fbcd6eb4ed154ac8be7e7dc72" FOREIGN KEY (course_id) REFERENCES public.courses(id);
+
+ALTER TABLE ONLY public.course_methods
+    ADD CONSTRAINT "FK_b65806d6baf43fbfa16751d9d5c" FOREIGN KEY (course_id) REFERENCES public.courses(id);
+
+ALTER TABLE ONLY public.course_schedules
+    ADD CONSTRAINT "FK_f0cd61820798323cb06ca91105d" FOREIGN KEY (course_id) REFERENCES public.courses(id);
+
+COMMIT;

--- a/db/migrations/000005_reproduce_timetable_tables.down.sql
+++ b/db/migrations/000005_reproduce_timetable_tables.down.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+DROP INDEX IF EXISTS public."IDX_c102260e1ffed113fef8ead148";
+
+DROP INDEX IF EXISTS public."IDX_41594bc21c7a7adff5f2a4574c";
+
+DROP TABLE IF EXISTS public.registered_course_tags;
+
+DROP TABLE IF EXISTS public.tags;
+
+DROP INDEX IF EXISTS public."IDX_fbc9587b218000acc37d7c6385";
+
+DROP TABLE IF EXISTS public.registered_courses;
+
+DROP TYPE IF EXISTS public.registered_courses_methods_enum;
+
+COMMIT;

--- a/db/migrations/000005_reproduce_timetable_tables.up.sql
+++ b/db/migrations/000005_reproduce_timetable_tables.up.sql
@@ -1,0 +1,62 @@
+BEGIN;
+
+CREATE TYPE public.registered_courses_methods_enum AS ENUM (
+    'OnlineAsynchronous',
+    'OnlineSynchronous',
+    'FaceToFace',
+    'Others'
+);
+
+CREATE TABLE public.registered_course_tags (
+    tag uuid NOT NULL,
+    registered_course uuid NOT NULL
+);
+
+CREATE TABLE public.registered_courses (
+    id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    year smallint NOT NULL,
+    course_id uuid,
+    name text,
+    instractor text,
+    credit numeric,
+    methods public.registered_courses_methods_enum[],
+    schedules jsonb,
+    memo text NOT NULL,
+    attendance integer NOT NULL,
+    absence integer NOT NULL,
+    late integer NOT NULL
+);
+
+CREATE TABLE public.tags (
+    id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    name text NOT NULL,
+    "position" integer NOT NULL
+);
+
+ALTER TABLE ONLY public.registered_courses
+    ADD CONSTRAINT "PK_1aa4b72144999c7ac6f37e52fca" PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.registered_course_tags
+    ADD CONSTRAINT "PK_605d76e7c4a818b543daae4cdf2" PRIMARY KEY (tag, registered_course);
+
+ALTER TABLE ONLY public.tags
+    ADD CONSTRAINT "PK_e7dc17249a1148a1970748eda99" PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.tags
+    ADD CONSTRAINT "UQ_b861cf6ec9af09190780481a311" UNIQUE (user_id, "position") DEFERRABLE INITIALLY DEFERRED;
+
+CREATE INDEX "IDX_41594bc21c7a7adff5f2a4574c" ON public.registered_course_tags USING btree (registered_course);
+
+CREATE INDEX "IDX_c102260e1ffed113fef8ead148" ON public.registered_course_tags USING btree (tag);
+
+CREATE UNIQUE INDEX "IDX_fbc9587b218000acc37d7c6385" ON public.registered_courses USING btree (user_id, course_id);
+
+ALTER TABLE ONLY public.registered_course_tags
+    ADD CONSTRAINT "FK_41594bc21c7a7adff5f2a4574cc" FOREIGN KEY (registered_course) REFERENCES public.registered_courses(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.registered_course_tags
+    ADD CONSTRAINT "FK_c102260e1ffed113fef8ead1481" FOREIGN KEY (tag) REFERENCES public.tags(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+COMMIT;

--- a/db/migrations/000006_reproduce_information_tables.down.sql
+++ b/db/migrations/000006_reproduce_information_tables.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP TABLE IF EXISTS public.already_reads;
+
+DROP TABLE IF EXISTS public.information;
+
+COMMIT;

--- a/db/migrations/000006_reproduce_information_tables.up.sql
+++ b/db/migrations/000006_reproduce_information_tables.up.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+CREATE TABLE public.already_reads (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    information_id uuid NOT NULL,
+    read_user text NOT NULL,
+    read_at timestamp without time zone NOT NULL
+);
+
+CREATE TABLE public.information (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    title character varying NOT NULL,
+    content text NOT NULL,
+    published_at timestamp without time zone NOT NULL
+);
+
+ALTER TABLE ONLY public.information
+    ADD CONSTRAINT "PK_091c910b61c3170a50eaf22e0c4" PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.already_reads
+    ADD CONSTRAINT "PK_7b7e4dc4f3dac9076561acd7832" PRIMARY KEY (id);
+
+COMMIT;

--- a/db/migrations/000007_reproduce_session_tables.down.sql
+++ b/db/migrations/000007_reproduce_session_tables.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP INDEX IF EXISTS public."session.id_expired_at_index";
+
+DROP TABLE IF EXISTS public.session;
+
+COMMIT;

--- a/db/migrations/000007_reproduce_session_tables.up.sql
+++ b/db/migrations/000007_reproduce_session_tables.up.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+CREATE TABLE public.session (
+    id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    expired_at timestamp(3) without time zone NOT NULL
+);
+
+ALTER TABLE ONLY public.session
+    ADD CONSTRAINT session_pkey PRIMARY KEY (id);
+
+CREATE INDEX "session.id_expired_at_index" ON public.session USING btree (id, expired_at);
+
+COMMIT;

--- a/db/migrations/000008_reproduce_donation_tables.down.sql
+++ b/db/migrations/000008_reproduce_donation_tables.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS public.payment_users;
+
+COMMIT;

--- a/db/migrations/000008_reproduce_donation_tables.up.sql
+++ b/db/migrations/000008_reproduce_donation_tables.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+CREATE TABLE public.payment_users (
+    id text NOT NULL,
+    twinte_user_id uuid NOT NULL,
+    display_name text,
+    link text
+);
+
+ALTER TABLE ONLY public.payment_users
+    ADD CONSTRAINT "PK_1438bd4715f036ae4353ae95505" PRIMARY KEY (id);
+
+COMMIT;


### PR DESCRIPTION
## PRの目的
本番用のDBにおけるスキーマを再現するためのマイグレーションファイルを作成する。

## やったこと
takonomura 君に頂いた`pg_dump`の結果から本番用のDBにおけるスキーマを再現するためのマイグレーションファイルを作成しました。

up用のクエリは`pg_dump`の結果をもとにコピペしました。その際、不要だと思われるクエリ(cf. **削除したクエリの例**)を削除しました。

down用のクエリはup用のクエリと#1 で作成したdown用のクエリを参考にして作成しました。

## Reviewersに確認して欲しい箇所
- **削除したクエリの例**で挙がっているクエリを本当に削除しても問題ないかどうか？

## 削除したクエリの例

```
--
-- Name: SCHEMA public; Type: ACL; Schema: -; Owner: postgres
--

GRANT USAGE ON SCHEMA public TO readaccess;


--
-- Name: TABLE course_methods; Type: ACL; Schema: public; Owner: course
--

GRANT SELECT ON TABLE public.course_methods TO readaccess;
```

```
--
-- PostgreSQL database dump
--

-- Dumped from database version 11.22 (Debian 11.22-0+deb10u1)
-- Dumped by pg_dump version 11.22 (Debian 11.22-0+deb10u1)

SET statement_timeout = 0;
SET lock_timeout = 0;
SET idle_in_transaction_session_timeout = 0;
SET client_encoding = 'UTF8';
SET standard_conforming_strings = on;
SELECT pg_catalog.set_config('search_path', '', false);
SET check_function_bodies = false;
SET xmloption = content;
SET client_min_messages = warning;
SET row_security = off;

--
-- Name: public; Type: SCHEMA; Schema: -; Owner: postgres
--

CREATE SCHEMA public;


ALTER SCHEMA public OWNER TO postgres;

--
-- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: postgres
--

COMMENT ON SCHEMA public IS 'standard public schema';
```
```
ALTER TYPE public.course_schedules_module_enum OWNER TO postgres;

SET default_tablespace = '';

SET default_with_oids = false;

ALTER TABLE public.course_schedules OWNER TO course;
```
```
--
-- Name: _prisma_migrations; Type: TABLE; Schema: public; Owner: session
--

CREATE TABLE public._prisma_migrations (
    id character varying(36) NOT NULL,
    checksum character varying(64) NOT NULL,
    finished_at timestamp with time zone,
    migration_name character varying(255) NOT NULL,
    logs text,
    rolled_back_at timestamp with time zone,
    started_at timestamp with time zone DEFAULT now() NOT NULL,
    applied_steps_count integer DEFAULT 0 NOT NULL
);


ALTER TABLE public._prisma_migrations OWNER TO session;
```